### PR TITLE
Adding Dutch language and adding possibility to put the currency sign before the amounts

### DIFF
--- a/documentation.tex
+++ b/documentation.tex
@@ -59,7 +59,7 @@
 	framexleftmargin=2.4em,
 	showstringspaces=false,
 	language=TeX,
-	morekeywords={\documentclass,\begin,\end,\usepackage,\makeinvoice,\setinvoicetitle,\setinvoicenumber,\setreceivername,\setreceiveraddress,\setname,\setaddress,\setphonenumber,\setemail,\setyourref,\setourref,\setinvoicedate,\setdeadline,\additem,\setsubtotal,\setvat,\settotal,\setaccountnumber, \setsummary, \setcurrency, \setvattext, \setaccounttext},
+	morekeywords={\documentclass,\begin,\end,\usepackage,\makeinvoice,\setcurrencysignfirst,\setinvoicetitle,\setinvoicenumber,\setreceivername,\setreceiveraddress,\setname,\setaddress,\setphonenumber,\setemail,\setyourref,\setourref,\setinvoicedate,\setdeadline,\additem,\setsubtotal,\setvat,\settotal,\setaccountnumber, \setsummary, \setcurrency, \setvattext, \setaccounttext},
 	commentstyle=\color{source_brown}\ttfamily,
 	keywordstyle=\color{source_blue}\ttfamily,
 	stringstyle=\color{source_orange},
@@ -97,12 +97,13 @@
 \chapter{Package overview}
 The \texttt{simpleinvoice} package lets you easily typeset professional-looking invoices, and makes sure that all the legally required information is on the invoice.
 
-The package respects the global language set in the document, or can be loaded with another language specified. The languages currently supported are English, Norwegian (bokmål), French and German.
+The package respects the global language set in the document, or can be loaded with another language specified. The languages currently supported are English, Norwegian (bokmål), French, Dutch and German.
 
 
 Following are a list of all available commands, detailed description are available in \cref{sec:commanddetails}.
 
 \begin{itemize}
+	\item \nameref{par:setcurrencysignfirst}
 	\item \nameref{par:setinvoicenumber}
 	\item \nameref{par:setreceivername}
 	\item \nameref{par:setreceiveraddress}
@@ -151,9 +152,16 @@ The package is loaded with the \verb|\usepackage| command. If no language is spe
 \end{document}
 \end{lstlisting}
 
-
 \section{Description of all available commands}
 \label{sec:commanddetails}
+
+\subsection{{\textbackslash}setcurrencysignfirst} \label{par:setcurrencysignfirst}
+Overrides the standard value of the "currencysignfirst" variable. Set as a default to no, if it is set to yes, all the amounts will be printed with the currency sign before the amount ("\$ 3" instead of "3 \$")
+Example:
+\begin{lstlisting}
+\setcurrencysignfirst{yes}
+\end{lstlisting}
+
 \subsection{{\textbackslash}setinvoicetitle}
 Overrides the standard title of the invoice. Optional command. Takes one argument: the new title.
 Example:

--- a/simpleinvoice.sty
+++ b/simpleinvoice.sty
@@ -16,6 +16,8 @@
 \DeclareOption{USenglish}{\def \INV@lang {eng}}
 \DeclareOption{french}{\def \INV@lang {fr}}
 \DeclareOption{francais}{\def \INV@lang {fr}}
+\DeclareOption{dutch}{\def \INV@lang {nl}}
+\DeclareOption{nederlands}{\def \INV@lang {nl}}
 \DeclareOption{norsk}{\def \INV@lang     {nobm}}
 \DeclareOption{norwegian}{\def \INV@lang {nobm}}
 \DeclareOption{bokmaal}{\def \INV@lang {nobm}}
@@ -58,6 +60,23 @@
 \def \INV@text@totallong@fr {Total}
 \def \INV@text@accountnum@fr {Numéro de compte}
 \def \INV@text@warning@fr {En payant après la date limite, des intérêts et des frais peuvent être appliqués.}
+
+\def \INV@text@invoice@nl {Factuur}
+\def \INV@text@ourref@nl {Ons kenmerk}
+\def \INV@text@yourref@nl {Uw kenmerk}
+\def \INV@text@invnum@nl {Factuurnummer}
+\def \INV@text@invdate@nl {Factuurdatum}
+\def \INV@text@deadline@nl {Uiterste betalingstermijn}
+\def \INV@text@description@nl {Beschrijving}
+\def \INV@text@itemprice@nl {Prijs}
+\def \INV@text@vat@nl {BTW}
+\def \INV@text@itemtotal@nl {Som}
+\def \INV@text@subtotal@nl {Subtotaal}
+\def \INV@text@total@nl {Totaal}
+\def \INV@text@paymentinfo@nl {Betalingsinformatie}
+\def \INV@text@totallong@nl {Totaal}
+\def \INV@text@accountnum@nl {Rekeningnummer}
+\def \INV@text@warning@nl {Extra kosten kunnen in rekening worden gebracht bij overschrijding van het betalingstermijn}
 
 \def \INV@text@invoice@nobm {Faktura}
 \def \INV@text@ourref@nobm {Vår ref}

--- a/simpleinvoice.sty
+++ b/simpleinvoice.sty
@@ -43,8 +43,8 @@
 \def \INV@text@warning@eng {By paying after deadline, additional interest and fees may apply.}
 
 \def \INV@text@invoice@fr {Facture}
-\def \INV@text@ourref@fr {Notre référent}
-\def \INV@text@yourref@fr {Votre référent}
+\def \INV@text@ourref@fr {Notre référence}
+\def \INV@text@yourref@fr {Votre référence}
 \def \INV@text@invnum@fr {Numéro de facture}
 \def \INV@text@invdate@fr {Date de facturation}
 \def \INV@text@deadline@fr {Date limite de paiement}

--- a/simpleinvoice.sty
+++ b/simpleinvoice.sty
@@ -131,7 +131,7 @@
 \def \INV@text@accountnum {\csname INV@text@accountnum@\INV@lang \endcsname}
 \def \INV@text@warning {\csname INV@text@warning@\INV@lang \endcsname}
 \def \INV@text@currency {}
-
+\def \INV@text@currencysignfirst {no}
 
 % Import neccesary libraries
 \RequirePackage{advdate}
@@ -160,6 +160,9 @@
 
 % Commands
 \RequirePackage{etoolbox}
+
+% If/then/else statements
+\RequirePackage{ifthen}
 
 % Line seperator
 \newcommand{\linesep}{\vspace{6pt} {\color{linecolor}\hrule} \vspace{6pt}}
@@ -195,7 +198,10 @@
 \newcommand{\setourref}[1]{\def \INV@content@ourref {#1}}
 \newcommand{\setinvoicedate}[1]{\def \INV@content@date {#1}}
 \newcommand{\setdeadline}[1]{\def \INV@content@deadline {\DayAfter[#1]}}
-\newcommand{\additem}[4]{\ifdef{\INV@content@list}{\appto \INV@content@list {\\ #1 & #2 \INV@text@currency & #3 \% & #4 \INV@text@currency}}{\def \INV@content@list {#1 & #2 \INV@text@currency& #3 \% & #4 \INV@text@currency}}}
+\newcommand{\setcurrencysignfirst}[1]{\def \INV@text@currencysignfirst {#1}}
+% command to print the values as '$ 3' or '3 $'
+\newcommand{\printcurrencyvalue}[1]{\ifthenelse{\equal{\INV@text@currencysignfirst}{no}}{#1 \INV@text@currency}{\INV@text@currency{} #1}}
+\newcommand{\additem}[4]{\ifdef{\INV@content@list}{\appto \INV@content@list {\\ #1 & \printcurrencyvalue{#2} & #3 \% & \printcurrencyvalue{#4}}}{\def \INV@content@list {#1 & \printcurrencyvalue{#2}& #3 \% & \printcurrencyvalue{#4}}}}
 \newcommand{\setsubtotal}[1]{\def \INV@content@subtotal {#1}}
 \newcommand{\setvat}[1]{\def \INV@content@vat {#1}}
 \newcommand{\settotal}[1]{\def \INV@content@total {#1}}
@@ -244,9 +250,9 @@
 	\hfill
 	\renewcommand{\arraystretch}{1}
 	\begin{tabular}{r r}
-		\csname INV@text@subtotal\endcsname: \hspace{10pt} & \INV@content@subtotal \INV@text@currency\\
-		\csname INV@text@vat\endcsname: \hspace{10pt} & \INV@content@vat \INV@text@currency\\
-		{\Large \csname INV@text@total\endcsname: \hspace{10pt}} & {\Large \INV@content@total \INV@text@currency}
+		\csname INV@text@subtotal\endcsname: \hspace{10pt} & \printcurrencyvalue{\INV@content@subtotal}\\
+		\csname INV@text@vat\endcsname: \hspace{10pt} & \printcurrencyvalue{\INV@content@vat}\\
+		{\Large \csname INV@text@total\endcsname: \hspace{10pt}} & {\Large \printcurrencyvalue{\INV@content@total}}
 	\end{tabular}
 
 	\vfill
@@ -256,7 +262,7 @@
 		\linesep
 		\begin{tabularx}{\textwidth}{X r}
 			\csname INV@text@invnum\endcsname: & \INV@content@num  \\
-			\csname INV@text@totallong\endcsname: & \INV@content@total \INV@text@currency\\
+			\csname INV@text@totallong\endcsname: & \printcurrencyvalue{\INV@content@total}\\
 			\csname INV@text@accountnum\endcsname: & \INV@content@accountnum
 		\end{tabularx}
 


### PR DESCRIPTION
1. Added the Dutch language
2. Corrected a little mistake in the French language
3. Added the "currencysignfirst" variable. It defaults to "no" but if set to "yes" with the command "setcurrencysignfirst", all the amounts will be printed with the currency sign first.